### PR TITLE
[Feature] Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-template.yml
+++ b/.github/ISSUE_TEMPLATE/bug-template.yml
@@ -25,21 +25,21 @@ body:
     id: trace-id
     attributes:
       label: What is the trace id of the call?
-      description: Please provide the trace id of the call. If you don't have one, please provide route + request models in the problem description.
-      placeholder: trace-id
+      description: Please provide the trace id of the call. If you don't have one or you cannot find it, please provide the request route + request model here.
+      placeholder: The trace-id of the call.
     validations:
       required: false
   - type: textarea
     id: workspace-info
     attributes:
-      label: What is the workspace url?
-      description: Please provide the url to your workspace or your workspace id.
-      placeholder: my-awesome-workspace.awork.io
+      label: Which workspace are you using?
+      description: Please provide the url to your workspace or your workspace id so we can filter for your calls or find the relevant entities.
+      placeholder: my-awesome-workspace.awork.io / 64e2d583-a9a7-e811-bce7-00155d315056
     validations:
       required: false
   - type: textarea
     id: logs
     attributes:
-      label: Relevant error response
+      label: Relevant error responses
       description: Please copy and paste any relevant log output or error response that you got back from the API. This will be automatically formatted into code, so no need for backticks.
       render: shell

--- a/.github/ISSUE_TEMPLATE/bug-template.yml
+++ b/.github/ISSUE_TEMPLATE/bug-template.yml
@@ -28,7 +28,7 @@ body:
       description: Please provide the trace id of the call. If you don't have one or you cannot find it, please provide the request route + request model here.
       placeholder: The trace-id of the call.
     validations:
-      required: false
+      required: true
   - type: textarea
     id: logs
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug-template.yml
+++ b/.github/ISSUE_TEMPLATE/bug-template.yml
@@ -25,7 +25,7 @@ body:
     id: trace-id
     attributes:
       label: What is the trace id of the call?
-      description: Please provide the trace id of the call. If you don't have one or you cannot find it, please provide the request route + request model here.
+      description: Please provide the trace id of the call. If you don't have one, please provide the request route + request model here.
       placeholder: The trace-id of the call.
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/bug-template.yml
+++ b/.github/ISSUE_TEMPLATE/bug-template.yml
@@ -30,16 +30,13 @@ body:
     validations:
       required: false
   - type: textarea
-    id: workspace-info
-    attributes:
-      label: Which workspace are you using?
-      description: Please provide the url to your workspace or your workspace id so we can filter for your calls or find the relevant entities.
-      placeholder: my-awesome-workspace.awork.io / 64e2d583-a9a7-e811-bce7-00155d315056
-    validations:
-      required: false
-  - type: textarea
     id: logs
     attributes:
       label: Relevant error responses
       description: Please copy and paste any relevant log output or error response that you got back from the API. This will be automatically formatted into code, so no need for backticks.
       render: shell
+  - type: markdown
+    attributes:
+      value: |
+        ## Disclaimer
+        Please be aware that all conversations in this GitHub repo are public, therefore please do not include private/confidential information such as workspace url, security tokens or personal information like e-mail addresses, names etc.

--- a/.github/ISSUE_TEMPLATE/bug-template.yml
+++ b/.github/ISSUE_TEMPLATE/bug-template.yml
@@ -1,0 +1,45 @@
+name: Bug Report
+description: This is the template to report a bug for the awork API.
+title: "[Bug]: Please provide a quick summary of the problem"
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for informing us about a bug in our API. Please provide us with the necessary details, so we can help you as fast as possible.
+  - type: markdown
+    attributes:
+      value: |
+        ## What infos do we need in order to help?
+        Please provide us with a trace id of the failing call and a detailed problem description including expected behaviour.
+        The trace-id can be found in the response headers. It looks like this: `trace-id: 2ab931e5606e3ccd`.
+  - type: textarea
+    id: problem-description
+    attributes:
+      label: What happened?
+      description: Tell us in detail what problem occurred. Please also tell us, what you would expect to happen.
+      placeholder: Tell us what happend, how we can repro it and what you expect.
+    validations:
+      required: true
+  - type: textarea
+    id: trace-id
+    attributes:
+      label: What is the trace id of the call?
+      description: Please provide the trace id of the call. If you don't have one, please provide route + request models in the problem description.
+      placeholder: trace-id
+    validations:
+      required: false
+  - type: textarea
+    id: workspace-info
+    attributes:
+      label: What is the workspace url?
+      description: Please provide the url to your workspace or your workspace id.
+      placeholder: my-awesome-workspace.awork.io
+    validations:
+      required: false
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant error response
+      description: Please copy and paste any relevant log output or error response that you got back from the API. This will be automatically formatted into code, so no need for backticks.
+      render: shell

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: awork Support
+    url: support@awork.io
+    about: Please ask none API related questions about awork here.

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,36 @@
+name: Question
+description: This is the template to ask a general question for the awork API. For bugs please use the specialized bug template.
+title: "[Question]: Please provide a quick summary of your question"
+labels: ["question"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for working with our API. We try to make our API as easy to use as possible and provide very good documentation. If you have any questions or feature requests please let us know and we will make sure to help you as fast as possible.
+  - type: markdown
+    attributes:
+      value: |
+        ## What infos do we need in order to help?
+        If you ask us a question, please make sure to formulate it clear and to give us as many additional information as possible. If your question is about a specific endpoint/call, please provide us with a trace id of the call and a detailed description including expected behaviour.
+        The trace-id can be found in the response headers. It looks like this: `trace-id: 2ab931e5606e3ccd`.
+  - type: textarea
+    id: question
+    attributes:
+      label: What is your question?
+      description: Tell us in detail what question you have. If you have a endpoint that is working other than expected, please provide us with the expected behaviour.
+      placeholder: Your question.
+    validations:
+      required: true
+  - type: textarea
+    id: trace-id
+    attributes:
+      label: Do you have a trace id of the call?
+      description: If your question is about a specific call, please provide the trace id of the call. If you don't have one or you cannot find it, please provide the request route + request model here.
+      placeholder: The trace-id of the call.
+    validations:
+      required: false
+  - type: markdown
+    attributes:
+      value: |
+        ## Disclaimer
+        Please be aware that all conversations in this GitHub repo are public, therefore please do not include private/confidential information such as workspace url, security tokens or personal information like e-mail addresses, names etc.

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -25,7 +25,7 @@ body:
     id: trace-id
     attributes:
       label: Do you have a trace id of the call?
-      description: If your question is about a specific call, please provide the trace id of the call. If you don't have one or you cannot find it, please provide the request route + request model here.
+      description: If your question is about a specific call, please provide the trace id of the call. If you don't have one, please provide the request route + request model here.
       placeholder: The trace-id of the call.
     validations:
       required: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,10 @@
+<!--- Provide a general summary of your changes in the Title above -->
+
+## Description
+<!--- Briefly describe your changes -->
+
+## References
+<!--- Provide a link to a task, concept, Slack conversation or other resource to support this change -->
+
+## How has this been tested?
+<!--- Explain how you tested these changes, i.e. unit tests, local testing, cluster... -->


### PR DESCRIPTION
## Description
Adds a new template for bugs that has text areas for problem description and asks for additional infos such as trace ids, workspace infos and error responses.

Adds the default template for PRs that we use in other services.

### Todos
Add special templates for questions and feature requests.